### PR TITLE
finish big num display #9

### DIFF
--- a/components/sidebar/CurrencyCard.tsx
+++ b/components/sidebar/CurrencyCard.tsx
@@ -13,12 +13,12 @@ type Props = {
   className?: string;
 };
 
-const fmtAmt = (n: number) =>
+const fmtAmt = (value: number, code: string) =>
   new Intl.NumberFormat(undefined, {
     style: "currency",
-    currency: "AUD",
+    currency: code,
     maximumFractionDigits: 2,
-  }).format(n);
+  }).format(value);
 
 const fmtRate = (n: number) =>
   new Intl.NumberFormat(undefined, {
@@ -46,8 +46,10 @@ export function CurrencyCard({
               )}
             </div>
           </div>
-          <div className="text-xl font-semibold tabular-nums">
-            {amount == null ? "—" : fmtAmt(amount)}
+          <div className="max-w-[220px] overflow-x-auto">
+            <div className="text-xl font-semibold tabular-nums" style={{ display: "inline-block", whiteSpace: "nowrap" }}>
+            {amount == null ? "—" : fmtAmt(amount, code)}
+            </div>
           </div>
         </div>
 

--- a/components/sidebar/CurrencySidebar.tsx
+++ b/components/sidebar/CurrencySidebar.tsx
@@ -54,7 +54,6 @@ export function CurrencySidebar() {
             <div className="flex items-center gap-2 text-sm font-medium uppercase">
               <span className="text-2xl leading-none">🇦🇺</span>
               <span>AUD</span>
-              {/* <ChevronDown className="h-4 w-4 text-muted-foreground" /> */}
             </div>
 
             <div className="flex-1 pl-1">


### PR DESCRIPTION
This pull request updates the currency formatting in the `CurrencyCard` component to support multiple currencies, rather than being hardcoded to AUD. It also improves the layout for displaying large currency amounts by making the amount horizontally scrollable if necessary.

Currency formatting improvements:

* Updated the `fmtAmt` function in `CurrencyCard.tsx` to accept both a value and a currency code, allowing dynamic formatting of different currencies instead of always using AUD.
* Modified the usage of `fmtAmt` in the `CurrencyCard` component to pass the appropriate currency code, ensuring that the displayed amount matches the selected currency.

UI enhancements:

* Wrapped the currency amount display in a horizontally scrollable container to prevent overflow and ensure readability for large numbers.

Code cleanup:

* Removed a commented-out line related to the currency dropdown chevron in `CurrencySidebar.tsx` for cleaner code.